### PR TITLE
Add a new column: total time

### DIFF
--- a/curl-benchmark.py
+++ b/curl-benchmark.py
@@ -54,6 +54,7 @@ time_column_data = [
     ("Request\nsent", 4),
     ("  TTFB", 2),
     ("Content\ndownload", 4),
+    (" Total", 8),
 ]
 time_columns = [ time_metric_col(i, *args) for i, args in enumerate(time_column_data) ]
 
@@ -103,6 +104,7 @@ def call_curl(url):
         if metric == 0: metric = last_metric
         metrics.append(metric - last_metric)
         last_metric = metric
+    metrics.append(last_metric) # now, last_metric contains "total"
 
     records.append(metrics)
     render = { "metrics": metrics, "first": vars["http_code"] }


### PR DESCRIPTION
Hi!

This PR adds a new column that shows the total time of a request.

I found this new column would be very useful.

```
$ ./curl-benchmark.py https://www.google.com/
              DNS      TCP        SSL  Request           Content        
     Code  lookup  connect  handshake     sent    TTFB  download   Total
      200    14.0     11.0       41.0      0.0    77.0       3.0   146.0
      200     1.0     14.0       46.0      0.0    71.0       5.0   137.0
      200     2.0     14.0       52.0      0.0    73.0       6.0   147.0
      200     2.0     16.0       52.0      0.0    78.0       7.0   155.0
      200     1.0     20.0       50.0      0.0    87.0       5.0   163.0
      200     1.0     17.0       46.0      0.0    79.0       7.0   150.0
      200     1.0     14.0       44.0      1.0   515.0       2.0   577.0
      200     1.0     15.0       49.0      0.0    98.0       6.0   169.0

     min:     1.0     11.0       41.0      0.0    71.0       2.0   137.0
     avg:     2.9     15.1       47.5      0.1   134.8       5.1   205.5
     med:     1.0     15.0       49.0      0.0    79.0       6.0   155.0
     max:    14.0     20.0       52.0      1.0   515.0       7.0   577.0
     dev:  147.0%    16.3%       7.7%   264.6%  106.8%     33.0%   68.5%
                requests: 8    samples: 8    failures: 0  
```

![image](https://github.com/mildsunrise/curl-benchmark/assets/13638709/81fa5d75-bc10-430d-97be-7bd870bd3f3d)

btw. there's an issue #4 that mentions such a feature